### PR TITLE
Fix page scrolling when touching minicolors panel on mobile

### DIFF
--- a/jquery.minicolors.css
+++ b/jquery.minicolors.css
@@ -45,6 +45,7 @@
   z-index: 99999;
   box-sizing: content-box;
   display: none;
+  touch-action: none;
 }
 
 .minicolors-panel.minicolors-visible {


### PR DESCRIPTION
I'm not sure how better to test this. Maybe test on your demo page before merging?